### PR TITLE
Navbar Farbe wieder zurück

### DIFF
--- a/_sass/_chaospott.scss
+++ b/_sass/_chaospott.scss
@@ -35,7 +35,7 @@ body {
 }
 
 .navbar {
-  background-color: #bdbfa8;
+  background-color: $background-color;
   border: none;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
   .divider-vertical {


### PR DESCRIPTION
Da ich bei der letzten PR die Farbe .navbar etwas zu stark verdunkelt habe, was darin resultierte, dass die Fontfarben nicht mehr richtig passten, habe ich die Farbe wieder auf $background-color gesetzt. 

Allerdings ist der box-shadow noch da, weswegen sich die .navbar immer noch besser vom normalen Content absetzt.
